### PR TITLE
GH-2 - Set the 'BP_JVM_VERSION' in workload.yaml for TAP Deployment. …

### DIFF
--- a/kubernetes/tap/workload.yaml
+++ b/kubernetes/tap/workload.yaml
@@ -6,6 +6,10 @@ metadata:
     apps.tanzu.vmware.com/workload-type: web
     app.kubernetes.io/part-of: hello-fun
 spec:
+  build:
+    env:
+      - name: BP_JVM_VERSION
+        value: "11"
   source:
     git:
       url: https://github.com/sample-accelerators/hello-fun.git


### PR DESCRIPTION
…Will be changed by the Java Fragment.

The updated Java Fragment will replace the JVM version only when key BP_JVM_VERSION exists. The addition behavior is removed.